### PR TITLE
Additional formats

### DIFF
--- a/dans-file-formats-schema.json
+++ b/dans-file-formats-schema.json
@@ -14,12 +14,16 @@
                 "title": {
                   "type": "string"
                 },
+                "url": {
+                  "type": "string"
+                },
                 "lang": {
                   "type": "string"
                 }
               },
               "required": [
                 "title",
+                "url",
                 "lang"
               ]
             }
@@ -31,22 +35,34 @@
             {
               "type": "object",
               "properties": {
-                "name": {
-                  "type": "string"
-                },
                 "file-ext": {
-                  "type": "string"
-                },
-                "dissemination": {
                   "type": "array",
                   "items": [
                     {
-                      "type": "string"
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "dissemination": {
+                          "type": "array",
+                          "items": [
+                            {
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "preservation": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "dissemination",
+                        "preservation"
+                      ]
                     }
                   ]
-                },
-                "preservation": {
-                  "type": "string"
                 },
                 "info": {
                   "type": "array",
@@ -54,6 +70,9 @@
                     {
                       "type": "object",
                       "properties": {
+                        "title": {
+                          "type": "string"
+                        },
                         "url": {
                           "type": "string"
                         },
@@ -62,6 +81,7 @@
                         }
                       },
                       "required": [
+                        "title",
                         "url",
                         "lang"
                       ]
@@ -69,6 +89,9 @@
                     {
                       "type": "object",
                       "properties": {
+                        "title": {
+                          "type": "string"
+                        },
                         "url": {
                           "type": "string"
                         },
@@ -77,6 +100,7 @@
                         }
                       },
                       "required": [
+                        "title",
                         "url",
                         "lang"
                       ]
@@ -85,32 +109,41 @@
                 }
               },
               "required": [
-                "name",
                 "file-ext",
-                "dissemination",
-                "preservation",
                 "info"
               ]
             },
             {
               "type": "object",
               "properties": {
-                "name": {
-                  "type": "string"
-                },
                 "file-ext": {
-                  "type": "string"
-                },
-                "dissemination": {
                   "type": "array",
                   "items": [
                     {
-                      "type": "string"
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "dissemination": {
+                          "type": "array",
+                          "items": [
+                            {
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "preservation": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "dissemination",
+                        "preservation"
+                      ]
                     }
                   ]
-                },
-                "preservation": {
-                  "type": "string"
                 },
                 "info": {
                   "type": "array",
@@ -118,6 +151,9 @@
                     {
                       "type": "object",
                       "properties": {
+                        "title": {
+                          "type": "string"
+                        },
                         "url": {
                           "type": "string"
                         },
@@ -126,6 +162,7 @@
                         }
                       },
                       "required": [
+                        "title",
                         "url",
                         "lang"
                       ]
@@ -133,6 +170,9 @@
                     {
                       "type": "object",
                       "properties": {
+                        "title": {
+                          "type": "string"
+                        },
                         "url": {
                           "type": "string"
                         },
@@ -141,6 +181,7 @@
                         }
                       },
                       "required": [
+                        "title",
                         "url",
                         "lang"
                       ]
@@ -149,10 +190,7 @@
                 }
               },
               "required": [
-                "name",
                 "file-ext",
-                "dissemination",
-                "preservation",
                 "info"
               ]
             }
@@ -164,36 +202,81 @@
             {
               "type": "object",
               "properties": {
-                "name": {
-                  "type": "string"
-                },
                 "file-ext": {
-                  "type": "string"
-                },
-                "pre-ingest": {
-                  "type": "string"
-                },
-                "dissemination": {
                   "type": "array",
                   "items": [
                     {
-                      "type": "string"
-                    },
-                    {
-                      "type": "string"
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "dissemination": {
+                          "type": "array",
+                          "items": [
+                            {
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "preservation": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "dissemination",
+                        "preservation"
+                      ]
                     }
                   ]
                 },
-                "preservation": {
-                  "type": "string"
+                "info": {
+                  "type": "array",
+                  "items": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "title": {
+                          "type": "string"
+                        },
+                        "url": {
+                          "type": "string"
+                        },
+                        "lang": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "title",
+                        "url",
+                        "lang"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "title": {
+                          "type": "string"
+                        },
+                        "url": {
+                          "type": "string"
+                        },
+                        "lang": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "title",
+                        "url",
+                        "lang"
+                      ]
+                    }
+                  ]
                 }
               },
               "required": [
-                "name",
                 "file-ext",
-                "pre-ingest",
-                "dissemination",
-                "preservation",
                 "info"
               ]
             }

--- a/dans-file-formats.json
+++ b/dans-file-formats.json
@@ -3,16 +3,17 @@
         "type": [
             {
                 "title": "Tekstdocumenten",
+                "url": "https://dans.knaw.nl/nl/bestandsformaten/tekstdocumenten/",
                 "lang": "nl"
             },
             {
                 "title": "Text documents",
+                "url": "https://dans.knaw.nl/en/file-formats/text-documents/",
                 "lang": "en"
             }
         ],
         "preferred-format": [
             {
-                "name": "PDF/A",
                 "file-ext": [
                     {
                         "name": "pdf",
@@ -22,17 +23,18 @@
                 ],
                 "info": [
                     {
+                        "title": "PDF/A",
                         "url": "https://dans.knaw.nl/bestandsformaten/tekstdocumenten/pdf-a/",
                         "lang": "nl"
                     },
                     {
+                        "title": "PDF/A",
                         "url": "https://dans.knaw.nl/bestandsformaten/tekstdocumenten/pdf-a/",
                         "lang": "en"
                     }
                 ]
             },
             {
-                "name": "ODT",
                 "file-ext": [
                     {
                         "name": "odt",
@@ -42,10 +44,12 @@
                 ],
                 "info": [
                     {
+                        "title": "ODT",
                         "url": "https://dans.knaw.nl/bestandsformaten/tekstdocumenten/opendocument-text-odt/",
                         "lang": "nl"
                     },
                     {
+                        "title": "ODT",
                         "url": "https://dans.knaw.nl/bestandsformaten/tekstdocumenten/opendocument-text-odt/",
                         "lang": "en"
                     }
@@ -54,7 +58,6 @@
         ],
         "non-preferred-format": [
             {
-                "name": "Microsoft Word",
                 "file-ext": [
                     {
                         "name": "doc",
@@ -64,17 +67,18 @@
                 ],
                 "info": [
                     {
+                        "title": "Microsoft Word",
                         "url": "https://dans.knaw.nl/bestandsformaten/tekstdocumenten/microsoft-word-doc-en-office-open-xml-docx/",
                         "lang": "nl"
                     },
                     {
+                        "title": "Microsoft Word",
                         "url": "https://dans.knaw.nl/en/file-formats/text-documents/microsoft-word-and-office-open-xml/",
                         "lang": "en"
                     }
                 ]
             },
             {
-                "name": "Office Open XML",
                 "file-ext": [
                     {
                         "name": "docx",
@@ -84,17 +88,18 @@
                 ],
                 "info": [
                     {
+                        "title": "Office Open XML",
                         "url": "https://dans.knaw.nl/nl/bestandsformaten/tekstdocumenten/microsoft-word-doc-en-office-open-xml-docx/",
                         "lang": "nl"
                     },
                     {
+                        "title": "Office Open XML",
                         "url": "https://dans.knaw.nl/en/file-formats/text-documents/microsoft-word-and-office-open-xml/",
                         "lang": "en"
                     }
                 ]
             },
             {
-                "name": "Rich Text File",
                 "file-ext": [
                     {
                         "name": "rtf",
@@ -104,17 +109,18 @@
                 ],
                 "info": [
                     {
+                        "title": "Rich Text File",
                         "url": "https://dans.knaw.nl/bestandsformaten/tekstdocumenten/rich-text-file-rtf/",
                         "lang": "nl"
                     },
                     {
+                        "title": "Rich Text File",
                         "url": "https://dans.knaw.nl/en/file-formats/text-documents/rich-text-file-rtf/",
                         "lang": "en"
                     }
                 ]
             },
             {
-                "name": "PDF other than PDF/A ",
                 "file-ext": [
                     {
                         "name": "pdf",
@@ -124,10 +130,12 @@
                 ],
                 "info": [
                     {
+                        "title": "PDF anders dan PDF/A",
                         "url": "https://dans.knaw.nl/bestandsformaten/tekstdocumenten/pdf-pdf/",
                         "lang": "nl"
                     },
                     {
+                        "title": "PDF other than PDF/A",
                         "url": "https://dans.knaw.nl/en/file-formats/text-documents/pdf-pdf/",
                         "lang": "en"
                     }
@@ -139,16 +147,17 @@
         "type": [
             {
                 "title": "Platte tekst",
+                "url": "https://dans.knaw.nl/nl/bestandsformaten/platte-tekst/",
                 "lang": "nl"
             },
             {
                 "title": "Plain text",
+                "url": "https://dans.knaw.nl/en/file-formats/plain-text/",
                 "lang": "en"
             }
         ],
         "preferred-format": [
             {
-                "name": "Unicode text",
                 "file-ext": [
                     {
                         "name": "txt",
@@ -158,10 +167,12 @@
                 ],
                 "info": [
                     {
+                        "title": "Unicode text",
                         "url": "https://dans.knaw.nl/bestandsformaten/platte-tekst/unicode/",
                         "lang": "nl"
                     },
                     {
+                        "title": "Unicode text",
                         "url": "https://dans.knaw.nl/en/file-formats/plain-text/unicode/",
                         "lang": "en"
                     }
@@ -171,7 +182,6 @@
         ],
         "non-preferred-format": [
             {
-                "name": "Non-Unicode text",
                 "file-ext": [
                     {
                         "name": "txt",
@@ -181,10 +191,12 @@
                 ],
                 "info": [
                     {
+                        "title": "Non-Unicode text",
                         "url": "https://dans.knaw.nl/bestandsformaten/platte-tekst/non-unicode/",
                         "lang": "nl"
                     },
                     {
+                        "title": "Non-Unicode text",
                         "url": "https://dans.knaw.nl/en/file-formats/plain-text/non-unicode/",
                         "lang": "en"
                     }
@@ -197,16 +209,17 @@
         "type": [
             {
                 "title": "Opmaaktaal",
+                "url": "https://dans.knaw.nl/nl/bestandsformaten/opmaaktaal/",
                 "lang": "nl"
             },
             {
                 "title": "Markup language",
+                "url": "https://dans.knaw.nl/en/file-formats/markup-language/",
                 "lang": "en"
             }
         ],
         "preferred-format": [
             {
-                "name": "XML",
                 "file-ext": [
                     {
                         "name": "xml",
@@ -216,17 +229,18 @@
                 ],
                 "info": [
                     {
+                        "title": "XML",
                         "url": "https://dans.knaw.nl/nl/bestandsformaten/opmaaktaal/xml/",
                         "lang": "nl"
                     },
                     {
+                        "title": "XML",
                         "url": "https://dans.knaw.nl/en/file-formats/markup-language/xml/",
                         "lang": "en"
                     }
                 ]
             },
             {
-                "name": "HTML",
                 "file-ext": [
                     {
                         "name": "html",
@@ -236,17 +250,18 @@
                 ],
                 "info": [
                     {
+                        "title": "HTML",
                         "url": "https://dans.knaw.nl/nl/bestandsformaten/opmaaktaal/html/",
                         "lang": "nl"
                     },
                     {
+                        "title": "HTML",
                         "url": "https://dans.knaw.nl/en/file-formats/markup-language/html/",
                         "lang": "en"
                     }
                 ]
             },
             {
-                "name": "Related files",
                 "file-ext": [
                     {
                         "name": "css",
@@ -271,10 +286,12 @@
                 ],
                 "info": [
                     {
+                        "title": "Gerelateerde bestanden",
                         "url": "",
                         "lang": "nl"
                     },
                     {
+                        "title": "Related files",
                         "url": "",
                         "lang": "en"
                     }
@@ -283,7 +300,6 @@
         ],
         "non-preferred-format": [
             {
-                "name": "SGML",
                 "file-ext": [
                     {
                         "name": "sgml",
@@ -293,17 +309,18 @@
                 ],
                 "info": [
                     {
+                        "title": "SGML",
                         "url": "https://dans.knaw.nl/bestandsformaten/opmaaktaal/sgml/",
                         "lang": "nl"
                     },
                     {
+                        "title": "SGML",
                         "url": "https://dans.knaw.nl/en/file-formats/markup-language/sgml/",
                         "lang": "en"
                     }
                 ]
             },
             {
-                "name": "Markdown",
                 "file-ext": [
                     {
                         "name": "md",
@@ -313,10 +330,12 @@
                 ],
                 "info": [
                     {
+                        "title": "Markdown",
                         "url": "https://dans.knaw.nl/bestandsformaten/opmaaktaal/markdown/",
                         "lang": "nl"
                     },
                     {
+                        "title": "Markdown",
                         "url": "https://dans.knaw.nl/en/file-formats/markup-language/markdown/",
                         "lang": "en"
                     }
@@ -328,51 +347,56 @@
         "type": [
             {
                 "title": "Programmeertaal",
+                "url": "https://dans.knaw.nl/bestandsformaten/programmeertaal/",
                 "lang": "nl"
             },
             {
                 "title": "Programming languages",
+                "url": "https://dans.knaw.nl/en/file-formats/programming-languages/",
                 "lang": "en"
             }
         ],
         "preferred-format": [
             {
-                "name": "MATLAB",
                 "file-ext": [],
                 "info": [
                     {
+                        "title": "MATLAB",
                         "url": "https://dans.knaw.nl/bestandsformaten/programmeertaal/matlab/",
                         "lang": "nl"
                     },
                     {
+                        "title": "MATLAB",
                         "url": "https://dans.knaw.nl/en/file-formats/programming-languages/matlab/",
                         "lang": "en"
                     }
                 ]
             },
             {
-                "name": "NetCDF",
                 "file-ext": [],
                 "info": [
                     {
+                        "title": "NetCDF",
                         "url": "https://dans.knaw.nl/bestandsformaten/programmeertaal/netcdf/",
                         "lang": "nl"
                     },
                     {
+                        "title": "NetCDF",
                         "url": "https://dans.knaw.nl/en/file-formats/programming-languages/netcdf/",
                         "lang": "en"
                     }
                 ]
             },
             {
-                "name": "Text-Fabric",
                 "file-ext": [],
                 "info": [
                     {
+                        "title": "Text-Fabric",
                         "url": "https://dans.knaw.nl/nl/bestandsformaten/programmeertaal/text-fabric/",
                         "lang": "nl"
                     },
                     {
+                        "title": "Text-Fabric",
                         "url": "https://dans.knaw.nl/en/file-formats/programming-languages/text-fabric/",
                         "lang": "en"
                     }
@@ -386,16 +410,17 @@
         "type": [
             {
                 "title": "Spreadsheets",
+                "url": "https://dans.knaw.nl/nl/bestandsformaten/spreadsheets/",
                 "lang": "nl"
             },
             {
                 "title": "Spreadsheets",
+                "url": "https://dans.knaw.nl/en/file-formats/spreadsheets/",
                 "lang": "en"
             }
         ],
         "preferred-format": [
             {
-                "name": "ODS",
                 "file-ext": [
                     {
                         "name": "ods",
@@ -405,17 +430,18 @@
                 ],
                 "info": [
                     {
+                        "title": "ODS",
                         "url": "https://dans.knaw.nl/bestandsformaten/spreadsheets/ods/",
                         "lang": "nl"
                     },
                     {
+                        "title": "ODS",
                         "url": "https://dans.knaw.nl/en/file-formats/spreadsheets/ods/",
                         "lang": "en"
                     }
                 ]
             },
             {
-                "name": "CSV",
                 "file-ext": [
                     {
                         "name": "csv",
@@ -425,10 +451,12 @@
                 ],
                 "info": [
                     {
+                        "title": "CSV",
                         "url": "https://dans.knaw.nl/bestandsformaten/databases/csv/",
                         "lang": "nl"
                     },
                     {
+                        "title": "CSV",
                         "url": "https://dans.knaw.nl/en/file-formats/databases/csv/",
                         "lang": "en"
                     }
@@ -437,7 +465,6 @@
         ],
         "non-preferred-format": [
             {
-                "name": "Microsoft Excel",
                 "file-ext": [
                     {
                         "name": "xls",
@@ -447,17 +474,18 @@
                 ],
                 "info": [
                     {
+                        "title": "Microsoft Excel",
                         "url": "https://dans.knaw.nl/bestandsformaten/spreadsheets/microsoft-excel/",
                         "lang": "nl"
                     },
                     {
+                        "title": "Microsoft Excel",
                         "url": "https://dans.knaw.nl/en/file-formats/spreadsheets/microsoft-excel/",
                         "lang": "en"
                     }
                 ]
             },
             {
-                "name": "Office Open XML Workbook",
                 "file-ext": [
                     {
                         "name": "xlxs",
@@ -467,17 +495,18 @@
                 ],
                 "info": [
                     {
+                        "title": "Office Open XML Workbook",
                         "url": "https://dans.knaw.nl/bestandsformaten/spreadsheets/office-open-xml-workbook/",
                         "lang": "nl"
                     },
                     {
+                        "title": "Office Open XML Workbook",
                         "url": "https://dans.knaw.nl/en/file-formats/spreadsheets/office-open-xml-workbook/",
                         "lang": "en"
                     }
                 ]
             },
             {
-                "name": "PDF/A",
                 "file-ext": [
                     {
                         "name": "pdf",
@@ -487,10 +516,12 @@
                 ],
                 "info": [
                     {
+                        "title": "PDF/A",
                         "url": "https://dans.knaw.nl/bestandsformaten/spreadsheets/pdf-a/",
                         "lang": "nl"
                     },
                     {
+                        "title": "PDF/A",
                         "url": "https://dans.knaw.nl/en/file-formats/spreadsheets/pdf-a/",
                         "lang": "en"
                     }
@@ -502,16 +533,17 @@
         "type": [
             {
                 "title": "Databases",
+                "url": "https://dans.knaw.nl/nl/bestandsformaten/databases/",
                 "lang": "nl"
             },
             {
                 "title": "Databases",
+                "url": "https://dans.knaw.nl/en/file-formats/databases/",
                 "lang": "en"
             }
         ],
         "preferred-format": [
             {
-                "name": "SQL",
                 "file-ext": [
                     {
                         "name": "sql",
@@ -521,17 +553,18 @@
                 ],
                 "info": [
                     {
+                        "title": "SQL",
                         "url": "https://dans.knaw.nl/nl/bestandsformaten/databases/sql/",
                         "lang": "nl"
                     },
                     {
+                        "title": "SQL",
                         "url": "https://dans.knaw.nl/en/file-formats/databases/sql/",
                         "lang": "en"
                     }
                 ]
             },
             {
-                "name": "SIARD",
                 "file-ext": [
                     {
                         "name": "siard",
@@ -541,17 +574,18 @@
                 ],
                 "info": [
                     {
+                        "title": "SIARD",
                         "url": "https://dans.knaw.nl/nl/bestandsformaten/databases/siard/",
                         "lang": "nl"
                     },
                     {
+                        "title": "SIARD",
                         "url": "https://dans.knaw.nl/en/file-formats/databases/siard/",
                         "lang": "en"
                     }
                 ]
             },
             {
-                "name": "CSV",
                 "file-ext": [
                     {
                         "name": "csv",
@@ -561,10 +595,12 @@
                 ],
                 "info": [
                     {
+                        "title": "CSV",
                         "url": "https://dans.knaw.nl/nl/bestandsformaten/databases/csv/",
                         "lang": "nl"
                     },
                     {
+                        "title": "CSV",
                         "url": "https://dans.knaw.nl/en/file-formats/databases/csv/",
                         "lang": "en"
                     }
@@ -573,7 +609,6 @@
         ],
         "non-preferred-format": [
             {
-                "name": "Microsoft Access",
                 "file-ext": [
                     {
                         "name": "mdb",
@@ -588,17 +623,18 @@
                 ],
                 "info": [
                     {
+                        "title": "Microsoft Access",
                         "url": "https://dans.knaw.nl/nl/bestandsformaten/databases/microsoft-access/",
                         "lang": "nl"
                     },
                     {
+                        "title": "Microsoft Access",
                         "url": "https://dans.knaw.nl/en/file-formats/databases/microsoft-access/",
                         "lang": "en"
                     }
                 ]
             },
             {
-                "name": "dBase",
                 "file-ext": [
                     {
                         "name": "dbf",
@@ -608,17 +644,18 @@
                 ],
                 "info": [
                     {
+                        "title": "dBase",
                         "url": "https://dans.knaw.nl/nl/bestandsformaten/databases/dbase/",
                         "lang": "nl"
                     },
                     {
+                        "title": "dBase",
                         "url": "https://dans.knaw.nl/en/file-formats/databases/dbase/",
                         "lang": "en"
                     }
                 ]
             },
             {
-                "name": "HDF5",
                 "file-ext": [
                     {
                         "name": "hdf5",
@@ -638,10 +675,12 @@
                 ],
                 "info": [
                     {
+                        "title": "HDF5",
                         "url": "https://dans.knaw.nl/nl/bestandsformaten/databases/hierarchical-data-format-hdf5/",
                         "lang": "nl"
                     },
                     {
+                        "title": "HDF5",
                         "url": "https://dans.knaw.nl/en/file-formats/databases/hierarchical-data-format-hdf5/",
                         "lang": "en"
                     }
@@ -654,16 +693,17 @@
         "type": [
             {
                 "title": "Statistische data",
+                "url": "https://dans.knaw.nl/nl/bestandsformaten/statistische-data/",
                 "lang": "nl"
             },
             {
                 "title": "Statistical data",
+                "url": "https://dans.knaw.nl/en/file-formats/statistical-data/",
                 "lang": "en"
             }
         ],
         "preferred-format": [
             {
-                "name": "SPSS",
                 "file-ext": [
                     {
                         "name": "dat",
@@ -678,17 +718,18 @@
                 ],
                 "info": [
                     {
+                        "title": "SPSS",
                         "url": "https://dans.knaw.nl/bestandsformaten/statistische-data/data-en-setup/",
                         "lang": "nl"
                     },
                     {
+                        "title": "SPSS",
                         "url": "https://dans.knaw.nl/en/file-formats/statistical-data/data-and-setup/",
                         "lang": "en"
                     }
                 ]
             },
             {
-                "name": "STATA",
                 "file-ext": [
                     {
                         "name": "dat",
@@ -703,24 +744,27 @@
                 ],
                 "info": [
                     {
+                        "title": "STATA",
                         "url": "https://dans.knaw.nl/bestandsformaten/statistische-data/data-en-setup/",
                         "lang": "nl"
                     },
                     {
+                        "title": "STATA",
                         "url": "https://dans.knaw.nl/en/file-formats/statistical-data/data-and-setup/",
                         "lang": "en"
                     }
                 ]
             },
             {
-                "name": "R",
                 "file-ext": [],
                 "info": [
                     {
+                        "title": "R",
                         "url": "https://dans.knaw.nl/bestandsformaten/statistische-data/r/",
                         "lang": "nl"
                     },
                     {
+                        "title": "R",
                         "url": "https://dans.knaw.nl/en/file-formats/statistical-data/r/",
                         "lang": "en"
                     }
@@ -729,7 +773,6 @@
         ],
         "non-preferred-format": [
             {
-                "name": "SPSS Portable",
                 "file-ext": [
                     {
                         "name": "por",
@@ -739,17 +782,18 @@
                 ],
                 "info": [
                     {
+                        "title": "SPSS Portable",
                         "url": "https://dans.knaw.nl/bestandsformaten/statistische-data/spss-portable/",
                         "lang": "nl"
                     },
                     {
+                        "title": "SPSS Portable",
                         "url": "https://dans.knaw.nl/en/file-formats/statistical-data/spss-portable/",
                         "lang": "en"
                     }
                 ]
             },
             {
-                "name": "SPSS",
                 "file-ext": [
                     {
                         "name": "sav",
@@ -759,17 +803,18 @@
                 ],
                 "info": [
                     {
+                        "title": "SPSS",
                         "url": "https://dans.knaw.nl/bestandsformaten/statistische-data/spss-sav/",
                         "lang": "nl"
                     },
                     {
+                        "title": "SPSS",
                         "url": "https://dans.knaw.nl/en/file-formats/statistical-data/spss-sav/",
                         "lang": "en"
                     }
                 ]
             },
             {
-                "name": "STATA",
                 "file-ext": [
                     {
                         "name": "dta",
@@ -779,17 +824,18 @@
                 ],
                 "info": [
                     {
+                        "title": "STATA",
                         "url": "https://dans.knaw.nl/bestandsformaten/statistische-data/stata/",
                         "lang": "nl"
                     },
                     {
+                        "title": "STATA",
                         "url": "https://dans.knaw.nl/en/file-formats/statistical-data/stata/",
                         "lang": "en"
                     }
                 ]
             },
             {
-                "name": "SAS",
                 "file-ext": [
                     {
                         "name": "7dat",
@@ -809,10 +855,12 @@
                 ],
                 "info": [
                     {
+                        "title": "SAS",
                         "url": "https://dans.knaw.nl/bestandsformaten/statistische-data/sas/",
                         "lang": "nl"
                     },
                     {
+                        "title": "SAS",
                         "url": "https://dans.knaw.nl/en/file-formats/statistical-data/sas/",
                         "lang": "en"
                     }
@@ -825,16 +873,17 @@
         "type": [
             {
                 "title": "Afbeeldingen (raster)",
+                "url": "https://dans.knaw.nl/nl/bestandsformaten/afbeeldingen-raster/",
                 "lang": "nl"
             },
             {
                 "title": "Raster images",
+                "url": "https://dans.knaw.nl/en/file-formats/images-raster/",
                 "lang": "en"
             }
         ],
         "preferred-format": [
             {
-                "name": "JPEG",
                 "file-ext": [
                     {
                         "name": "jpg",
@@ -849,17 +898,18 @@
                 ],
                 "info": [
                     {
+                        "title": "JPEG",
                         "url": "https://dans.knaw.nl/nl/bestandsformaten/afbeeldingen-raster/jpeg/",
                         "lang": "nl"
                     },
                     {
+                        "title": "JPEG",
                         "url": "https://dans.knaw.nl/en/file-formats/images-raster/jpeg/",
                         "lang": "en"
                     }
                 ]
             },
             {
-                "name": "TIFF",
                 "file-ext": [
                     {
                         "name": "tif",
@@ -874,17 +924,18 @@
                 ],
                 "info": [
                     {
+                        "title": "TIFF",
                         "url": "https://dans.knaw.nl/nl/bestandsformaten/afbeeldingen-raster/tiff/",
                         "lang": "nl"
                     },
                     {
+                        "title": "TIFF",
                         "url": "https://dans.knaw.nl/en/file-formats/images-raster/tiff/",
                         "lang": "en"
                     }
                 ]
             },
             {
-                "name": "PNG",
                 "file-ext": [
                     {
                         "name": "png",
@@ -894,17 +945,18 @@
                 ],
                 "info": [
                     {
+                        "title": "PNG",
                         "url": "https://dans.knaw.nl/nl/bestandsformaten/afbeeldingen-raster/png/",
                         "lang": "nl"
                     },
                     {
+                        "title": "PNG",
                         "url": "https://dans.knaw.nl/en/file-formats/images-raster/png/",
                         "lang": "en"
                     }
                 ]
             },
             {
-                "name": "JPEG 2000",
                 "file-ext": [
                     {
                         "name": "jp2",
@@ -914,17 +966,18 @@
                 ],
                 "info": [
                     {
+                        "title": "JPEG 2000",
                         "url": "https://dans.knaw.nl/nl/bestandsformaten/afbeeldingen-raster/jpeg-2000/",
                         "lang": "nl"
                     },
                     {
+                        "title": "JPEG 2000",
                         "url": "https://dans.knaw.nl/en/file-formats/images-raster/jpeg-2000/",
                         "lang": "en"
                     }
                 ]
             },
             {
-                "name": "DICOM",
                 "file-ext": [
                     {
                         "name": "dcm",
@@ -934,10 +987,12 @@
                 ],
                 "info": [
                     {
+                        "title": "DICOM",
                         "url": "https://dans.knaw.nl/nl/bestandsformaten/afbeeldingen-raster/dicom/",
                         "lang": "nl"
                     },
                     {
+                        "title": "DICOM",
                         "url": "https://dans.knaw.nl/en/file-formats/images-raster/dicom/",
                         "lang": "en"
                     }
@@ -951,16 +1006,17 @@
         "type": [
             {
                 "title": "Afbeeldingen (vector)",
+                "url": "https://dans.knaw.nl/nl/bestandsformaten/afbeeldingen-vector/",
                 "lang": "nl"
             },
             {
                 "title": "Vector images ",
+                "url": "https://dans.knaw.nl/en/file-formats/images-vector/",
                 "lang": "en"
             }
         ],
         "preferred-format": [
             {
-                "name": "SVG",
                 "file-ext": [
                     {
                         "name": "svg",
@@ -970,10 +1026,12 @@
                 ],
                 "info": [
                     {
+                        "title": "SVG",
                         "url": "https://dans.knaw.nl/bestandsformaten/afbeeldingen-vector/svg/",
                         "lang": "nl"
                     },
                     {
+                        "title": "SVG",
                         "url": "https://dans.knaw.nl/en/file-formats/images-vector/svg/",
                         "lang": "en"
                     }
@@ -982,7 +1040,6 @@
         ],
         "non-preferred-format": [
             {
-                "name": "Adobe Illustrator",
                 "file-ext": [
                     {
                         "name": "ai",
@@ -992,17 +1049,18 @@
                 ],
                 "info": [
                     {
+                        "title": "Adobe Illustrator",
                         "url": "https://dans.knaw.nl/bestandsformaten/afbeeldingen-vector/adobe-illustrator/",
                         "lang": "nl"
                     },
                     {
+                        "title": "Adobe Illustrator",
                         "url": "https://dans.knaw.nl/en/file-formats/images-vector/adobe-illustrator/",
                         "lang": "en"
                     }
                 ]
             },
             {
-                "name": "EPS",
                 "file-ext": [
                     {
                         "name": "eps",
@@ -1012,17 +1070,18 @@
                 ],
                 "info": [
                     {
+                        "title": "EPS",
                         "url": "https://dans.knaw.nl/bestandsformaten/afbeeldingen-vector/eps/",
                         "lang": "nl"
                     },
                     {
+                        "title": "EPS",
                         "url": "https://dans.knaw.nl/en/file-formats/images-vector/eps/",
                         "lang": "en"
                     }
                 ]
             },
             {
-                "name": "WMF/EMF",
                 "file-ext": [
                     {
                         "name": "wmf",
@@ -1037,17 +1096,18 @@
                 ],
                 "info": [
                     {
+                        "title": "WMF/EMF",
                         "url": "https://dans.knaw.nl/bestandsformaten/afbeeldingen-vector/wmf-emf/",
                         "lang": "nl"
                     },
                     {
+                        "title": "WMF/EMF",
                         "url": "https://dans.knaw.nl/en/file-formats/images-vector/wmf-emf/",
                         "lang": "en"
                     }
                 ]
             },
             {
-                "name": "CDR",
                 "file-ext": [
                     {
                         "name": "cdr",
@@ -1057,10 +1117,12 @@
                 ],
                 "info": [
                     {
+                        "title": "CDR",
                         "url": "https://dans.knaw.nl/bestandsformaten/afbeeldingen-vector/cdr/",
                         "lang": "nl"
                     },
                     {
+                        "title": "CDR",
                         "url": "https://dans.knaw.nl/en/file-formats/images-vector/cdr/",
                         "lang": "en"
                     }
@@ -1073,16 +1135,17 @@
         "type": [
             {
                 "title": "Audio",
+                "url": "https://dans.knaw.nl/nl/bestandsformaten/audio/",
                 "lang": "nl"
             },
             {
                 "title": "Audio",
+                "url": "https://dans.knaw.nl/en/file-formats/audio/",
                 "lang": "en"
             }
         ],
         "preferred-format": [
             {
-                "name": "BWF",
                 "file-ext": [
                     {
                         "name": "bwf",
@@ -1092,17 +1155,18 @@
                 ],
                 "info": [
                     {
+                        "title": "BWF",
                         "url": "https://dans.knaw.nl/bestandsformaten/audio/bwf/",
                         "lang": "nl"
                     },
                     {
+                        "title": "BWF",
                         "url": "https://dans.knaw.nl/en/file-formats/audio/bwf/",
                         "lang": "en"
                     }
                 ]
             },
             {
-                "name": "MXF",
                 "file-ext": [
                     {
                         "name": "mxf",
@@ -1112,17 +1176,18 @@
                 ],
                 "info": [
                     {
+                        "title": "MXF",
                         "url": "https://dans.knaw.nl/bestandsformaten/audio/mxf/",
                         "lang": "nl"
                     },
                     {
+                        "title": "MXF",
                         "url": "https://dans.knaw.nl/en/file-formats/audio/mxf/",
                         "lang": "en"
                     }
                 ]
             },
             {
-                "name": "Matroska",
                 "file-ext": [
                     {
                         "name": "mka",
@@ -1132,17 +1197,18 @@
                 ],
                 "info": [
                     {
+                        "title": "Matroska",
                         "url": "https://dans.knaw.nl/bestandsformaten/audio/matroska/",
                         "lang": "nl"
                     },
                     {
+                        "title": "Matroska",
                         "url": "https://dans.knaw.nl/en/file-formats/audio/matroska/",
                         "lang": "en"
                     }
                 ]
             },
             {
-                "name": "FLAC",
                 "file-ext": [
                     {
                         "name": "flac",
@@ -1152,17 +1218,18 @@
                 ],
                 "info": [
                     {
+                        "title": "FLAC",
                         "url": "https://dans.knaw.nl/nl/bestandsformaten/audio/flac/",
                         "lang": "nl"
                     },
                     {
+                        "title": "FLAC",
                         "url": "https://dans.knaw.nl/en/file-formats/audio/flac/",
                         "lang": "en"
                     }
                 ]
             },
             {
-                "name": "OPUS",
                 "file-ext": [
                     {
                         "name": "opus",
@@ -1172,10 +1239,12 @@
                 ],
                 "info": [
                     {
+                        "title": "OPUS",
                         "url": "https://dans.knaw.nl/nl/bestandsformaten/audio/opus/",
                         "lang": "nl"
                     },
                     {
+                        "title": "OPUS",
                         "url": "https://dans.knaw.nl/en/file-formats/audio/opus/",
                         "lang": "en"
                     }
@@ -1184,7 +1253,6 @@
         ],
         "non-preferred-format": [
             {
-                "name": "WAVE",
                 "file-ext": [
                     {
                         "name": "wav",
@@ -1194,17 +1262,18 @@
                 ],
                 "info": [
                     {
+                        "title": "WAVE",
                         "url": "https://dans.knaw.nl/bestandsformaten/audio/wave",
                         "lang": "nl"
                     },
                     {
+                        "title": "WAVE",
                         "url": "https://dans.knaw.nl/en/file-formats/audio/wav",
                         "lang": "en"
                     }
                 ]
             },
             {
-                "name": "MP3",
                 "file-ext": [
                     {
                         "name": "mp3",
@@ -1214,17 +1283,18 @@
                 ],
                 "info": [
                     {
+                        "title": "MP3",
                         "url": "https://dans.knaw.nl/nl/bestandsformaten/audio/mp3/",
                         "lang": "nl"
                     },
                     {
+                        "title": "MP3",
                         "url": "https://dans.knaw.nl/en/file-formats/audio/mp3/",
                         "lang": "en"
                     }
                 ]
             },
             {
-                "name": "AAC",
                 "file-ext": [
                     {
                         "name": "aac",
@@ -1239,17 +1309,18 @@
                 ],
                 "info": [
                     {
+                        "title": "AAC",
                         "url": "https://dans.knaw.nl/nl/bestandsformaten/audio/aac/",
                         "lang": "nl"
                     },
                     {
+                        "title": "AAC",
                         "url": "https://dans.knaw.nl/en/file-formats/audio/aac/",
                         "lang": "en"
                     }
                 ]
             },
             {
-                "name": "AIFF",
                 "file-ext": [
                     {
                         "name": "aif",
@@ -1264,10 +1335,12 @@
                 ],
                 "info": [
                     {
+                        "title": "AIFF",
                         "url": "https://dans.knaw.nl/nl/bestandsformaten/audio/aiff/",
                         "lang": "nl"
                     },
                     {
+                        "title": "AIFF",
                         "url": "https://dans.knaw.nl/en/file-formats/audio/aiff/",
                         "lang": "en"
                     }
@@ -1280,16 +1353,17 @@
         "type": [
             {
                 "title": "Video",
+                "url": "https://dans.knaw.nl/nl/bestandsformaten/video/",
                 "lang": "nl"
             },
             {
                 "title": "Video",
+                "url": "https://dans.knaw.nl/en/file-formats/video/",
                 "lang": "en"
             }
         ],
         "preferred-format": [
             {
-                "name": "MXF",
                 "file-ext": [
                     {
                         "name": "mxf",
@@ -1299,17 +1373,18 @@
                 ],
                 "info": [
                     {
+                        "title": "MXF",
                         "url": "https://dans.knaw.nl/nl/bestandsformaten/video/mxf/",
                         "lang": "nl"
                     },
                     {
+                        "title": "MXF",
                         "url": "https://dans.knaw.nl/en/file-formats/video/mxf/",
                         "lang": "en"
                     }
                 ]
             },
             {
-                "name": "Matroska",
                 "file-ext": [
                     {
                         "name": "mkv",
@@ -1319,10 +1394,12 @@
                 ],
                 "info": [
                     {
+                        "title": "Matroska",
                         "url": "https://dans.knaw.nl/nl/bestandsformaten/video/matroska/",
                         "lang": "nl"
                     },
                     {
+                        "title": "Matroska",
                         "url": "https://dans.knaw.nl/en/file-formats/video/matroska/",
                         "lang": "en"
                     }
@@ -1331,7 +1408,6 @@
         ],
         "non-preferred-format": [
             {
-                "name": "MPEG-4",
                 "file-ext": [
                     {
                         "name": "mp4",
@@ -1352,17 +1428,18 @@
                 ],
                 "info": [
                     {
+                        "title": "MPEG-4",
                         "url": "https://dans.knaw.nl/nl/bestandsformaten/video/mpeg-4/",
                         "lang": "nl"
                     },
                     {
+                        "title": "MPEG-4",
                         "url": "https://dans.knaw.nl/en/file-formats/video/mpeg-4/",
                         "lang": "en"
                     }
                 ]
             },
             {
-                "name": "MPEG-2",
                 "file-ext": [
                     {
                         "name": "mpg",
@@ -1387,17 +1464,18 @@
                 ],
                 "info": [
                     {
+                        "title": "MPEG-2",
                         "url": "https://dans.knaw.nl/nl/bestandsformaten/video/mpeg-2/",
                         "lang": "nl"
                     },
                     {
+                        "title": "MPEG-2",
                         "url": "https://dans.knaw.nl/en/file-formats/video/mpeg-2/",
                         "lang": "en"
                     }
                 ]
             },
             {
-                "name": "AVI",
                 "file-ext": [
                     {
                         "name": "avi",
@@ -1407,17 +1485,18 @@
                 ],
                 "info": [
                     {
+                        "title": "AVI",
                         "url": "https://dans.knaw.nl/nl/bestandsformaten/video/avi/",
                         "lang": "nl"
                     },
                     {
+                        "title": "AVI",
                         "url": "https://dans.knaw.nl/en/file-formats/video/avi/",
                         "lang": "en"
                     }
                 ]
             },
             {
-                "name": "QuickTime",
                 "file-ext": [
                     {
                         "name": "mov",
@@ -1432,10 +1511,12 @@
                 ],
                 "info": [
                     {
+                        "title": "QuickTime",
                         "url": "https://dans.knaw.nl/nl/bestandsformaten/video/quicktime/",
                         "lang": "nl"
                     },
                     {
+                        "title": "QuickTime",
                         "url": "https://dans.knaw.nl/en/file-formats/video/quicktime/",
                         "lang": "en"
                     }
@@ -1448,16 +1529,17 @@
         "type": [
             {
                 "title": "Computer Aided Design (CAD)",
+                "url": "https://dans.knaw.nl/nl/bestandsformaten/computer-aided-design-cad/",
                 "lang": "nl"
             },
             {
                 "title": "Computer Aided Design (CAD)",
+                "url": "https://dans.knaw.nl/en/file-formats/computer-aided-design-cad/",
                 "lang": "en"
             }
         ],
         "preferred-format": [
             {
-                "name": "AutoCAD DXF versie R12 (ASCII)",
                 "file-ext": [
                     {
                         "name": "dxf",
@@ -1467,11 +1549,884 @@
                 ],
                 "info": [
                     {
-                        "url": "https://dans.knaw.nl/nl/bestandsformaten/video/quicktime/",
+                        "title": "AutoCAD DXF versie R12 (ASCII)",
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/computer-aided-design-cad/autocad-dxf-versie-r12-ascii/",
                         "lang": "nl"
                     },
                     {
-                        "url": "https://dans.knaw.nl/en/file-formats/video/quicktime/",
+                        "title": "AutoCAD DXF version R12 (ASCII)",
+                        "url": "https://dans.knaw.nl/en/file-formats/computer-aided-design-cad/autocad-dxf-versie-r12-ascii/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "file-ext": [
+                    {
+                        "name": "svg",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "title": "SVG",
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/computer-aided-design-cad/svg/",
+                        "lang": "nl"
+                    },
+                    {
+                        "title": "SVG",
+                        "url": "https://dans.knaw.nl/en/file-formats/computer-aided-design-cad/svg/",
+                        "lang": "en"
+                    }
+                ]
+            }
+        ],
+        "non-preferred-format": [
+            {
+                "file-ext": [
+                    {
+                        "name": "dxf",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "title": "Autocad DXF, versie anders dan R12 (ASCII)",
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/computer-aided-design-cad/autocad-dxf-versie-anders-dan-r12-ascii/",
+                        "lang": "nl"
+                    },
+                    {
+                        "title": "Autocad DXF, version different than R12 (ASCII)",
+                        "url": "https://dans.knaw.nl/en/file-formats/computer-aided-design-cad/autocad-dxf-versie-anders-dan-r12-ascii/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "file-ext": [
+                    {
+                        "name": "dwg",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "title": "DWG",
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/computer-aided-design-cad/dwg/",
+                        "lang": "nl"
+                    },
+                    {
+                        "title": "DWG",
+                        "url": "https://dans.knaw.nl/en/file-formats/computer-aided-design-cad/dwg/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "file-ext": [
+                    {
+                        "name": "dgn",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "title": "DGN",
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/computer-aided-design-cad/dgn/",
+                        "lang": "nl"
+                    },
+                    {
+                        "title": "DGN",
+                        "url": "https://dans.knaw.nl/en/file-formats/computer-aided-design-cad/dgn/",
+                        "lang": "en"
+                    }
+                ]
+            }
+        ]
+    },
+
+    {
+        "type": [
+            {
+                "title": "Geografische Informatie  Systemen (GIS)",
+                "url": "https://dans.knaw.nl/nl/bestandsformaten/geografische-informatie-systemen-gis/",
+                "lang": "nl"
+            },
+            {
+                "title": "Geographical Information Systems (GIS)",
+                "url": "https://dans.knaw.nl/en/file-formats/geographical-information-systems-gis/",
+                "lang": "en"
+            }
+        ],
+        "preferred-format": [
+            {
+                "file-ext": [
+                    {
+                        "name": "gml",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "title": "GML",
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/geografische-informatie-systemen-gis/gml/",
+                        "lang": "nl"
+                    },
+                    {
+                        "title": "GML",
+                        "url": "https://dans.knaw.nl/en/file-formats/geographical-information-systems-gis/gml/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "file-ext": [
+                    {
+                        "name": "mif",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    },
+                    {
+                        "name": "mid",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "title": "MIF/MID",
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/geografische-informatie-systemen-gis/mif-mid/",
+                        "lang": "nl"
+                    },
+                    {
+                        "title": "MIF/MID",
+                        "url": "https://dans.knaw.nl/en/file-formats/geographical-information-systems-gis/mif-mid/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "file-ext": [
+                    {
+                        "name": "json",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "title": "GeoJSON",
+                        "url": "",
+                        "lang": "nl"
+                    },
+                    {
+                        "title": "GeoJSON",
+                        "url": "",
+                        "lang": "en"
+                    }
+                ]
+            }
+        ],
+        "non-preferred-format": [
+            {
+                "file-ext": [
+                    {
+                        "name": "shp",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "title": "Esri Shapefiles",
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/geografische-informatie-systemen-gis/esri-shapefile/",
+                        "lang": "nl"
+                    },
+                    {
+                        "title": "Esri Shapefiles",
+                        "url": "https://dans.knaw.nl/en/file-formats/geographical-information-systems-gis/esri-shapefile/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "file-ext": [
+                    {
+                        "name": "tab",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "title": "MapInfo",
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/geografische-informatie-systemen-gis/mapinfo/",
+                        "lang": "nl"
+                    },
+                    {
+                        "title": "MapInfo",
+                        "url": "https://dans.knaw.nl/en/file-formats/geographical-information-systems-gis/mapinfo/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "file-ext": [
+                    {
+                        "name": "kml",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    },
+                    {
+                        "name": "kmz",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "title": "KML",
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/geografische-informatie-systemen-gis/kml/",
+                        "lang": "nl"
+                    },
+                    {
+                        "title": "KML",
+                        "url": "https://dans.knaw.nl/en/file-formats/geographical-information-systems-gis/kml/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "file-ext": [
+                    {
+                        "name": "gdb",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "title": "Esri Geodatabase",
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/geografische-informatie-systemen-gis/esri-geodatabase/",
+                        "lang": "nl"
+                    },
+                    {
+                        "title": "Esri Geodatabase",
+                        "url": "https://dans.knaw.nl/en/file-formats/geographical-information-systems-gis/esri-geodatabase/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "file-ext": [
+                    {
+                        "name": "mxd",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    },
+                    {
+                        "name": "wor",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    },
+                    {
+                        "name": "qgs",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "title": "Projectbestanden/Workspaces",
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/geografische-informatie-systemen-gis/projectbestanden-workspaces/",
+                        "lang": "nl"
+                    },
+                    {
+                        "title": "Project files/Workspaces",
+                        "url": "https://dans.knaw.nl/en/file-formats/geographical-information-systems-gis/project-files-workspaces/",
+                        "lang": "en"
+                    }
+                ]
+            }
+        ]
+    },
+
+    {
+        "type": [
+            {
+                "title": "Afbeeldingen (georeferentie)",
+                "url": "https://dans.knaw.nl/nl/bestandsformaten/afbeeldingen-georeferentie/",
+                "lang": "nl"
+            },
+            {
+                "title": "Georeferenced images",
+                "url": "https://dans.knaw.nl/en/file-formats/images-georeference/",
+                "lang": "en"
+            }
+        ],
+        "preferred-format": [
+            {
+                "file-ext": [
+                    {
+                        "name": "tif",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    },
+                    {
+                        "name": "tiff",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "title": "GeoTIFF",
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/afbeeldingen-georeferentie/geotiff/",
+                        "lang": "nl"
+                    },
+                    {
+                        "title": "GeoTIFF",
+                        "url": "https://dans.knaw.nl/en/file-formats/images-georeference/geotiff/",
+                        "lang": "en"
+                    }
+                ]
+            }
+        ],
+        "non-preferred-format": [
+            {
+                "file-ext": [
+                    {
+                        "name": "tfw",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    },
+                    {
+                        "name": "tif",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "title": "TIFF World File",
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/afbeeldingen-georeferentie/tiff-world-file/",
+                        "lang": "nl"
+                    },
+                    {
+                        "title": "TIFF World File",
+                        "url": "https://dans.knaw.nl/en/file-formats/images-georeference/tiff-world-file/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "file-ext": [
+                    {
+                        "name": "jgw",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    },
+                    {
+                        "name": "jpg",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "title": "JPEG World File",
+                        "url": "https://dans.knaw.nl/bestandsformaten/afbeeldingen-georeferentie/jpeg-world-file/",
+                        "lang": "nl"
+                    },
+                    {
+                        "title": "JPEG World File",
+                        "url": "https://dans.knaw.nl/en/file-formats/images-georeference/jpeg-world-file/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "file-ext": [
+                    {
+                        "name": "img",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "title": "ERDAS IMAGINE File Format",
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/afbeeldingen-georeferentie/erdas-imagine-file-format/",
+                        "lang": "nl"
+                    },
+                    {
+                        "title": "ERDAS IMAGINE File Format",
+                        "url": "https://dans.knaw.nl/en/file-formats/images-georeference/erdas-imagine-file-format/",
+                        "lang": "en"
+                    }
+                ]
+            }
+        ]
+    },
+
+    {
+        "type": [
+            {
+                "title": "Raster GIS",
+                "url": "https://dans.knaw.nl/nl/bestandsformaten/raster-gis/",
+                "lang": "nl"
+            },
+            {
+                "title": "Raster GIS",
+                "url": "https://dans.knaw.nl/en/file-formats/raster-gis/",
+                "lang": "en"
+            }
+        ],
+        "preferred-format": [
+            {
+                "file-ext": [
+                    {
+                        "name": "asc",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    },
+                    {
+                        "name": "txt",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "title": "ASCII GRID",
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/raster-gis/ascii-grid/",
+                        "lang": "nl"
+                    },
+                    {
+                        "title": "ASCII GRID",
+                        "url": "https://dans.knaw.nl/en/file-formats/raster-gis/ascii-grid/",
+                        "lang": "en"
+                    }
+                ]
+            }
+        ],
+        "non-preferred-format": [
+            {
+                "file-ext": [
+                    {
+                        "name": "grd",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "title": "Esri GRID",
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/raster-gis/erdas-imagine-file-format/",
+                        "lang": "nl"
+                    },
+                    {
+                        "title": "Esri GRID",
+                        "url": "https://dans.knaw.nl/en/file-formats/raster-gis/erdas-imagine-file-format/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "file-ext": [
+                    {
+                        "name": "grd",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    },
+                    {
+                        "name": "srf",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "title": "Surfer Grid",
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/raster-gis/surfer-grid/",
+                        "lang": "nl"
+                    },
+                    {
+                        "title": "Surfer Grid",
+                        "url": "https://dans.knaw.nl/en/file-formats/raster-gis/surfer-grid/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "file-ext": [
+                    {
+                        "name": "img",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "title": "ERDAS IMAGINE File Format",
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/raster-gis/erdas-imagine-file-format/",
+                        "lang": "nl"
+                    },
+                    {
+                        "title": "ERDAS IMAGINE File Format",
+                        "url": "https://dans.knaw.nl/en/file-formats/raster-gis/erdas-imagine-file-format/",
+                        "lang": "en"
+                    }
+                ]
+            }
+        ]
+    },
+
+    {
+        "type": [
+            {
+                "title": "3D",
+                "url": "https://dans.knaw.nl/nl/bestandsformaten/3d/",
+                "lang": "nl"
+            },
+            {
+                "title": "3D",
+                "url": "https://dans.knaw.nl/en/file-formats/3d/",
+                "lang": "en"
+            }
+        ],
+        "preferred-format": [
+            {
+                "file-ext": [
+                    {
+                        "name": "obj",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "title": "WaveFront Object",
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/3d/wavefront-object/",
+                        "lang": "nl"
+                    },
+                    {
+                        "title": "WaveFront Object",
+                        "url": "https://dans.knaw.nl/en/file-formats/3d/wavefront-object/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "file-ext": [
+                    {
+                        "name": "ply",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "title": "Polygon file format",
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/3d/polygon-file-format/",
+                        "lang": "nl"
+                    },
+                    {
+                        "title": "Polygon file format",
+                        "url": "https://dans.knaw.nl/en/file-formats/3d/polygon-file-format/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "file-ext": [
+                    {
+                        "name": "x3d",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "title": "X3D",
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/3d/x3d/",
+                        "lang": "nl"
+                    },
+                    {
+                        "title": "X3D",
+                        "url": "https://dans.knaw.nl/en/file-formats/3d/x3d/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "file-ext": [
+                    {
+                        "name": "dae",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "title": "COLLADA",
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/3d/collada/",
+                        "lang": "nl"
+                    },
+                    {
+                        "title": "COLLADA",
+                        "url": "https://dans.knaw.nl/en/file-formats/3d/collada/",
+                        "lang": "en"
+                    }
+                ]
+            }
+        ],
+        "non-preferred-format": [
+            {
+                "file-ext": [
+                    {
+                        "name": "fbx",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "title": "Autodesk FBX",
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/3d/autodesk-fbx/",
+                        "lang": "nl"
+                    },
+                    {
+                        "title": "Autodesk FBX",
+                        "url": "https://dans.knaw.nl/en/file-formats/3d/autodesk-fbx/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "file-ext": [
+                    {
+                        "name": "blend",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "title": "Blender",
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/3d/blender/",
+                        "lang": "nl"
+                    },
+                    {
+                        "title": "Blender",
+                        "url": "https://dans.knaw.nl/en/file-formats/3d/blender/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "file-ext": [
+                    {
+                        "name": "pdf",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "title": "3D PDF",
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/3d/adobe-portable-document-format-3d-pdf/",
+                        "lang": "nl"
+                    },
+                    {
+                        "title": "3D PDF",
+                        "url": "https://dans.knaw.nl/en/file-formats/3d/adobe-portable-document-format-3d-pdf/",
+                        "lang": "en"
+                    }
+                ]
+            }
+        ]
+    },
+
+    {
+        "type": [
+            {
+                "title": "RDF",
+                "url": "https://dans.knaw.nl/nl/bestandsformaten/rdf-2/",
+                "lang": "nl"
+            },
+            {
+                "title": "RDF",
+                "url": "https://dans.knaw.nl/en/file-formats/rdf-2/",
+                "lang": "en"
+            }
+        ],
+        "preferred-format": [
+            {
+                "file-ext": [
+                    {
+                        "name": "rdf",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "title": "RDF/XML",
+                        "url": "",
+                        "lang": "nl"
+                    },
+                    {
+                        "title": "RDF/XML",
+                        "url": "",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "file-ext": [
+                    {
+                        "name": "trig",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "title": "Trig",
+                        "url": "",
+                        "lang": "nl"
+                    },
+                    {
+                        "title": "Trig",
+                        "url": "",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "file-ext": [
+                    {
+                        "name": "ttl",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "title": "Turtle",
+                        "url": "",
+                        "lang": "nl"
+                    },
+                    {
+                        "title": "Turtle",
+                        "url": "",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "file-ext": [
+                    {
+                        "name": "nt",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "title": "NTriples",
+                        "url": "",
+                        "lang": "nl"
+                    },
+                    {
+                        "title": "NTriples",
+                        "url": "",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "file-ext": [],
+                "info": [
+                    {
+                        "title": "JSON-LD",
+                        "url": "",
+                        "lang": "nl"
+                    },
+                    {
+                        "title": "JSON-LD",
+                        "url": "",
+                        "lang": "en"
+                    }
+                ]
+            }
+        ],
+        "non-preferred-format": []
+    },
+
+    {
+        "type": [
+            {
+                "title": "Computer Assisted Qualitative Data Analysis (CAQDAS)",
+                "url": "https://dans.knaw.nl/nl/bestandsformaten/computer-assisted-qualitative-data-analysis-caqdas/",
+                "lang": "nl"
+            },
+            {
+                "title": "Computer Assisted Qualitative Data Analysis (CAQDAS)",
+                "url": "https://dans.knaw.nl/en/file-formats/computer-assisted-qualitative-data-analysis-caqdas/",
+                "lang": "en"
+            }
+        ],
+        "preferred-format": [
+            {
+                "file-ext": [],
+                "info": [
+                    {
+                        "title": "REFI-QDA (Qualitative Data Analysis)",
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/computer-assisted-qualitative-data-analysis-caqdas/refi-qda-qualitative-data-analysis/",
+                        "lang": "nl"
+                    },
+                    {
+                        "title": "REFI-QDA (Qualitative Data Analysis)",
+                        "url": "https://dans.knaw.nl/en/file-formats/computer-assisted-qualitative-data-analysis-caqdas/refi-qda-qualitative-data-analysis/",
+                        "lang": "en"
+                    }
+                ]
+            }
+        ],
+        "non-preferred-format": [
+            {
+                "file-ext": [],
+                "info": [
+                    {
+                        "title": "ATLAS.TI copy bundle",
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/computer-assisted-qualitative-data-analysis-caqdas/atlas-ti-copy-bundle-en-nvivo-project-file/",
+                        "lang": "nl"
+                    },
+                    {
+                        "title": "ATLAS.TI copy bundle",
+                        "url": "https://dans.knaw.nl/en/file-formats/computer-assisted-qualitative-data-analysis-caqdas/atlas-ti-copy-bundle-and-nvivo-project-file-2/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "file-ext": [],
+                "info": [
+                    {
+                        "title": "NVivo project file",
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/computer-assisted-qualitative-data-analysis-caqdas/atlas-ti-copy-bundle-en-nvivo-project-file-2/",
+                        "lang": "nl"
+                    },
+                    {
+                        "title": "NVivo project file",
+                        "url": "https://dans.knaw.nl/en/file-formats/computer-assisted-qualitative-data-analysis-caqdas/atlas-ti-copy-bundle-and-nvivo-project-file/",
                         "lang": "en"
                     }
                 ]

--- a/dans-file-formats.json
+++ b/dans-file-formats.json
@@ -2,135 +2,24 @@
     {
         "type": [
             {
-                "title": "Audio",
-                "lang": "nl"
-            },
-            {
-                "title": "Audio",
-                "lang": "en"
-            }
-        ],
-        "preferred-format": [
-            {
-                "name": "BWF",
-                "file-ext": "bwf",
-                "dissemination": ["BMF"],
-                "preservation": "BMF",
-                "info": [
-                    {
-                        "url": "https://dans.knaw.nl/bestandsformaten/audio/bwf/",
-                        "lang": "nl"
-                    },
-                    {
-                        "url": "https://dans.knaw.nl/en/file-formats/audio/bwf/",
-                        "lang": "en"
-                    }
-                ]
-            },
-            {
-                "name": "MXF",
-                "file-ext": "mxf",
-                "dissemination": ["MXF"],
-                "preservation": "MXF",
-                "info": [
-                    {
-                        "url": "https://dans.knaw.nl/bestandsformaten/audio/mxf/",
-                        "lang": "nl"
-                    },
-                    {
-                        "url": "https://dans.knaw.nl/en/file-formats/audio/mxf/",
-                        "lang": "en"
-                    }
-                ]
-            },
-            {
-                "name": "Matroska",
-                "file-ext": "mka",
-                "dissemination": ["Matroska"],
-                "preservation": "Matroska",
-                "info": [
-                    {
-                        "url": "https://dans.knaw.nl/bestandsformaten/audio/matroska/",
-                        "lang": "nl"
-                    },
-                    {
-                        "url": "https://dans.knaw.nl/en/file-formats/audio/matroska/",
-                        "lang": "en"
-                    }
-                ]
-            }
-        ],
-        "non-preferred-format": [
-            {
-                "name": "M4A",
-                "file-ext": "m4a",
-                "pre-ingest": "",
-                "dissemination": ["M4A", "Matroska"],
-                "preservation": "Matroska",
-                "info": [
-                    {
-                        "url": "https://dans.knaw.nl/bestandsformaten/audio/m4a",
-                        "lang": "nl"
-                    },
-                    {
-                        "url": "https://dans.knaw.nl/en/file-formats/audio/m4a",
-                        "lang": "en"
-                    }
-                ]
-            },
-            {
-                "name": "WAVE",
-                "file-ext": "wav",
-                "pre-ingest": "",
-                "dissemination": ["WAVE", "BWF"],
-                "preservation": "BWF",
-                "info": [
-                    {
-                        "url": "https://dans.knaw.nl/bestandsformaten/audio/wave",
-                        "lang": "nl"
-                    },
-                    {
-                        "url": "https://dans.knaw.nl/en/file-formats/audio/wav",
-                        "lang": "en"
-                    }
-                ]
-            },
-            {
-                "name": "3GP",
-                "file-ext": "3gp",
-                "pre-ingest": "BWF",
-                "dissemination": ["3GP", "BWF"],
-                "preservation": "BWF",
-                "info": [
-                    {
-                        "url": "https://dans.knaw.nl/bestandsformaten/audio/3gp",
-                        "lang": "nl"
-                    },
-                    {
-                        "url": "https://dans.knaw.nl/en/file-formats/audio/3gp",
-                        "lang": "en"
-                    }
-                ]
-            }
-        ]
-    },
-    {
-        "type": [
-            {
                 "title": "Tekstdocumenten",
                 "lang": "nl"
             },
             {
-                "title": "Text document",
+                "title": "Text documents",
                 "lang": "en"
             }
         ],
         "preferred-format": [
             {
                 "name": "PDF/A",
-                "file-ext": "pdf",
-                "dissemination": ["PDF/A"],
-                "preservation": "PDF/A",
+                "file-ext": [
+                    {
+                        "name": "pdf",
+                        "dissemination": ["pdf"],
+                        "preservation": "pdf"
+                    }
+                ],
                 "info": [
                     {
                         "url": "https://dans.knaw.nl/bestandsformaten/tekstdocumenten/pdf-a/",
@@ -144,9 +33,13 @@
             },
             {
                 "name": "ODT",
-                "file-ext": "odt",
-                "dissemination": ["ODT"],
-                "preservation": "ODT",
+                "file-ext": [
+                    {
+                        "name": "odt",
+                        "dissemination": ["odt"],
+                        "preservation": "odt"
+                    }
+                ],
                 "info": [
                     {
                         "url": "https://dans.knaw.nl/bestandsformaten/tekstdocumenten/opendocument-text-odt/",
@@ -162,64 +55,80 @@
         "non-preferred-format": [
             {
                 "name": "Microsoft Word",
-                "file-ext": "doc",
-                "dissemination": ["?"],
-                "preservation": "?",
+                "file-ext": [
+                    {
+                        "name": "doc",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
                 "info": [
                     {
                         "url": "https://dans.knaw.nl/bestandsformaten/tekstdocumenten/microsoft-word-doc-en-office-open-xml-docx/",
                         "lang": "nl"
                     },
                     {
-                        "url": "https://dans.knaw.nl/bestandsformaten/tekstdocumenten/microsoft-word-doc-en-office-open-xml-docx/",
+                        "url": "https://dans.knaw.nl/en/file-formats/text-documents/microsoft-word-and-office-open-xml/",
                         "lang": "en"
                     }
                 ]
             },
             {
                 "name": "Office Open XML",
-                "file-ext": "docx",
-                "dissemination": ["?"],
-                "preservation": "?",
+                "file-ext": [
+                    {
+                        "name": "docx",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
                 "info": [
                     {
-                        "url": "https://dans.knaw.nl/bestandsformaten/tekstdocumenten/microsoft-word-doc-en-office-open-xml-docx/",
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/tekstdocumenten/microsoft-word-doc-en-office-open-xml-docx/",
                         "lang": "nl"
                     },
                     {
-                        "url": "https://dans.knaw.nl/bestandsformaten/tekstdocumenten/microsoft-word-doc-en-office-open-xml-docx/",
+                        "url": "https://dans.knaw.nl/en/file-formats/text-documents/microsoft-word-and-office-open-xml/",
                         "lang": "en"
                     }
                 ]
             },
             {
                 "name": "Rich Text File",
-                "file-ext": "rtf",
-                "dissemination": ["?"],
-                "preservation": "?",
+                "file-ext": [
+                    {
+                        "name": "rtf",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
                 "info": [
                     {
                         "url": "https://dans.knaw.nl/bestandsformaten/tekstdocumenten/rich-text-file-rtf/",
                         "lang": "nl"
                     },
                     {
-                        "url": "https://dans.knaw.nl/bestandsformaten/tekstdocumenten/rich-text-file-rtf/",
+                        "url": "https://dans.knaw.nl/en/file-formats/text-documents/rich-text-file-rtf/",
                         "lang": "en"
                     }
                 ]
             },
             {
                 "name": "PDF other than PDF/A ",
-                "file-ext": "pdf",
-                "dissemination": ["?"],
-                "preservation": "?",
+                "file-ext": [
+                    {
+                        "name": "pdf",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
                 "info": [
                     {
-                        "url": "",
+                        "url": "https://dans.knaw.nl/bestandsformaten/tekstdocumenten/pdf-pdf/",
                         "lang": "nl"
                     },
                     {
-                        "url": "https://dans.knaw.nl/bestandsformaten/tekstdocumenten/pdf-pdf/",
+                        "url": "https://dans.knaw.nl/en/file-formats/text-documents/pdf-pdf/",
                         "lang": "en"
                     }
                 ]
@@ -240,9 +149,13 @@
         "preferred-format": [
             {
                 "name": "Unicode text",
-                "file-ext": "txt",
-                "dissemination": ["Unicode text"],
-                "preservation": "Unicode text",
+                "file-ext": [
+                    {
+                        "name": "txt",
+                        "dissemination": ["txt"],
+                        "preservation": "txt"
+                    }
+                ],
                 "info": [
                     {
                         "url": "https://dans.knaw.nl/bestandsformaten/platte-tekst/unicode/",
@@ -259,9 +172,13 @@
         "non-preferred-format": [
             {
                 "name": "Non-Unicode text",
-                "file-ext": "txt",
-                "dissemination": ["?"],
-                "preservation": "?",
+                "file-ext": [
+                    {
+                        "name": "txt",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
                 "info": [
                     {
                         "url": "https://dans.knaw.nl/bestandsformaten/platte-tekst/non-unicode/",
@@ -279,18 +196,79 @@
     {
         "type": [
             {
-                "title": "",
+                "title": "Opmaaktaal",
                 "lang": "nl"
             },
             {
-                "title": "",
+                "title": "Markup language",
                 "lang": "en"
             }
         ],
         "preferred-format": [
             {
-                "name": "",
-                "file-ext": "",
+                "name": "XML",
+                "file-ext": [
+                    {
+                        "name": "xml",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/opmaaktaal/xml/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/markup-language/xml/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "name": "HTML",
+                "file-ext": [
+                    {
+                        "name": "html",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/opmaaktaal/html/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/markup-language/html/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "name": "Related files",
+                "file-ext": [
+                    {
+                        "name": "css",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    },
+                    {
+                        "name": "xslt",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    },
+                    {
+                        "name": "js",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    },
+                    {
+                        "name": "es",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
                 "info": [
                     {
                         "url": "",
@@ -305,19 +283,1199 @@
         ],
         "non-preferred-format": [
             {
-                "name": "",
-                "file-ext": "",
+                "name": "SGML",
+                "file-ext": [
+                    {
+                        "name": "sgml",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
                 "info": [
                     {
-                        "url": "",
+                        "url": "https://dans.knaw.nl/bestandsformaten/opmaaktaal/sgml/",
                         "lang": "nl"
                     },
                     {
-                        "url": "",
+                        "url": "https://dans.knaw.nl/en/file-formats/markup-language/sgml/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "name": "Markdown",
+                "file-ext": [
+                    {
+                        "name": "md",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/bestandsformaten/opmaaktaal/markdown/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/markup-language/markdown/",
                         "lang": "en"
                     }
                 ]
             }
          ]
+    },
+    {
+        "type": [
+            {
+                "title": "Programmeertaal",
+                "lang": "nl"
+            },
+            {
+                "title": "Programming languages",
+                "lang": "en"
+            }
+        ],
+        "preferred-format": [
+            {
+                "name": "MATLAB",
+                "file-ext": [],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/bestandsformaten/programmeertaal/matlab/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/programming-languages/matlab/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "name": "NetCDF",
+                "file-ext": [],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/bestandsformaten/programmeertaal/netcdf/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/programming-languages/netcdf/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "name": "Text-Fabric",
+                "file-ext": [],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/programmeertaal/text-fabric/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/programming-languages/text-fabric/",
+                        "lang": "en"
+                    }
+                ]
+            }
+        ],
+        "non-preferred-format": []
+    },
+
+    {
+        "type": [
+            {
+                "title": "Spreadsheets",
+                "lang": "nl"
+            },
+            {
+                "title": "Spreadsheets",
+                "lang": "en"
+            }
+        ],
+        "preferred-format": [
+            {
+                "name": "ODS",
+                "file-ext": [
+                    {
+                        "name": "ods",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/bestandsformaten/spreadsheets/ods/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/spreadsheets/ods/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "name": "CSV",
+                "file-ext": [
+                    {
+                        "name": "csv",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/bestandsformaten/databases/csv/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/databases/csv/",
+                        "lang": "en"
+                    }
+                ]
+            }
+        ],
+        "non-preferred-format": [
+            {
+                "name": "Microsoft Excel",
+                "file-ext": [
+                    {
+                        "name": "xls",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/bestandsformaten/spreadsheets/microsoft-excel/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/spreadsheets/microsoft-excel/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "name": "Office Open XML Workbook",
+                "file-ext": [
+                    {
+                        "name": "xlxs",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/bestandsformaten/spreadsheets/office-open-xml-workbook/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/spreadsheets/office-open-xml-workbook/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "name": "PDF/A",
+                "file-ext": [
+                    {
+                        "name": "pdf",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/bestandsformaten/spreadsheets/pdf-a/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/spreadsheets/pdf-a/",
+                        "lang": "en"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "type": [
+            {
+                "title": "Databases",
+                "lang": "nl"
+            },
+            {
+                "title": "Databases",
+                "lang": "en"
+            }
+        ],
+        "preferred-format": [
+            {
+                "name": "SQL",
+                "file-ext": [
+                    {
+                        "name": "sql",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/databases/sql/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/databases/sql/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "name": "SIARD",
+                "file-ext": [
+                    {
+                        "name": "siard",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/databases/siard/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/databases/siard/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "name": "CSV",
+                "file-ext": [
+                    {
+                        "name": "csv",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/databases/csv/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/databases/csv/",
+                        "lang": "en"
+                    }
+                ]
+            }
+        ],
+        "non-preferred-format": [
+            {
+                "name": "Microsoft Access",
+                "file-ext": [
+                    {
+                        "name": "mdb",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    },
+                    {
+                        "name": "accdb",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/databases/microsoft-access/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/databases/microsoft-access/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "name": "dBase",
+                "file-ext": [
+                    {
+                        "name": "dbf",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/databases/dbase/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/databases/dbase/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "name": "HDF5",
+                "file-ext": [
+                    {
+                        "name": "hdf5",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    },
+                    {
+                        "name": "he5",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    },
+                    {
+                        "name": "h5",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/databases/hierarchical-data-format-hdf5/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/databases/hierarchical-data-format-hdf5/",
+                        "lang": "en"
+                    }
+                ]
+            }
+        ]
+    },
+
+    {
+        "type": [
+            {
+                "title": "Statistische data",
+                "lang": "nl"
+            },
+            {
+                "title": "Statistical data",
+                "lang": "en"
+            }
+        ],
+        "preferred-format": [
+            {
+                "name": "SPSS",
+                "file-ext": [
+                    {
+                        "name": "dat",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    },
+                    {
+                        "name": "sps",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/bestandsformaten/statistische-data/data-en-setup/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/statistical-data/data-and-setup/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "name": "STATA",
+                "file-ext": [
+                    {
+                        "name": "dat",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    },
+                    {
+                        "name": "DO",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/bestandsformaten/statistische-data/data-en-setup/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/statistical-data/data-and-setup/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "name": "R",
+                "file-ext": [],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/bestandsformaten/statistische-data/r/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/statistical-data/r/",
+                        "lang": "en"
+                    }
+                ]
+            }
+        ],
+        "non-preferred-format": [
+            {
+                "name": "SPSS Portable",
+                "file-ext": [
+                    {
+                        "name": "por",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/bestandsformaten/statistische-data/spss-portable/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/statistical-data/spss-portable/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "name": "SPSS",
+                "file-ext": [
+                    {
+                        "name": "sav",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/bestandsformaten/statistische-data/spss-sav/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/statistical-data/spss-sav/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "name": "STATA",
+                "file-ext": [
+                    {
+                        "name": "dta",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/bestandsformaten/statistische-data/stata/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/statistical-data/stata/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "name": "SAS",
+                "file-ext": [
+                    {
+                        "name": "7dat",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    },
+                    {
+                        "name": "sd2",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    },
+                    {
+                        "name": "tpt",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/bestandsformaten/statistische-data/sas/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/statistical-data/sas/",
+                        "lang": "en"
+                    }
+                ]
+            }
+        ]
+    },
+
+    {
+        "type": [
+            {
+                "title": "Afbeeldingen (raster)",
+                "lang": "nl"
+            },
+            {
+                "title": "Raster images",
+                "lang": "en"
+            }
+        ],
+        "preferred-format": [
+            {
+                "name": "JPEG",
+                "file-ext": [
+                    {
+                        "name": "jpg",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    },
+                    {
+                        "name": "jpeg",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/afbeeldingen-raster/jpeg/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/images-raster/jpeg/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "name": "TIFF",
+                "file-ext": [
+                    {
+                        "name": "tif",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    },
+                    {
+                        "name": "tiff",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/afbeeldingen-raster/tiff/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/images-raster/tiff/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "name": "PNG",
+                "file-ext": [
+                    {
+                        "name": "png",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/afbeeldingen-raster/png/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/images-raster/png/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "name": "JPEG 2000",
+                "file-ext": [
+                    {
+                        "name": "jp2",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/afbeeldingen-raster/jpeg-2000/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/images-raster/jpeg-2000/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "name": "DICOM",
+                "file-ext": [
+                    {
+                        "name": "dcm",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/afbeeldingen-raster/dicom/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/images-raster/dicom/",
+                        "lang": "en"
+                    }
+                ]
+            }
+        ],
+        "non-preferred-format": []
+    },
+
+    {
+        "type": [
+            {
+                "title": "Afbeeldingen (vector)",
+                "lang": "nl"
+            },
+            {
+                "title": "Vector images ",
+                "lang": "en"
+            }
+        ],
+        "preferred-format": [
+            {
+                "name": "SVG",
+                "file-ext": [
+                    {
+                        "name": "svg",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/bestandsformaten/afbeeldingen-vector/svg/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/images-vector/svg/",
+                        "lang": "en"
+                    }
+                ]
+            }
+        ],
+        "non-preferred-format": [
+            {
+                "name": "Adobe Illustrator",
+                "file-ext": [
+                    {
+                        "name": "ai",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/bestandsformaten/afbeeldingen-vector/adobe-illustrator/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/images-vector/adobe-illustrator/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "name": "EPS",
+                "file-ext": [
+                    {
+                        "name": "eps",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/bestandsformaten/afbeeldingen-vector/eps/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/images-vector/eps/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "name": "WMF/EMF",
+                "file-ext": [
+                    {
+                        "name": "wmf",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    },
+                    {
+                        "name": "emf",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/bestandsformaten/afbeeldingen-vector/wmf-emf/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/images-vector/wmf-emf/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "name": "CDR",
+                "file-ext": [
+                    {
+                        "name": "cdr",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/bestandsformaten/afbeeldingen-vector/cdr/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/images-vector/cdr/",
+                        "lang": "en"
+                    }
+                ]
+            }
+        ]
+    },
+
+    {
+        "type": [
+            {
+                "title": "Audio",
+                "lang": "nl"
+            },
+            {
+                "title": "Audio",
+                "lang": "en"
+            }
+        ],
+        "preferred-format": [
+            {
+                "name": "BWF",
+                "file-ext": [
+                    {
+                        "name": "bwf",
+                        "dissemination": ["bwf"],
+                        "preservation": "bwf"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/bestandsformaten/audio/bwf/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/audio/bwf/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "name": "MXF",
+                "file-ext": [
+                    {
+                        "name": "mxf",
+                        "dissemination": ["mxf"],
+                        "preservation": "mxf"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/bestandsformaten/audio/mxf/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/audio/mxf/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "name": "Matroska",
+                "file-ext": [
+                    {
+                        "name": "mka",
+                        "dissemination": ["mka"],
+                        "preservation": "mka"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/bestandsformaten/audio/matroska/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/audio/matroska/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "name": "FLAC",
+                "file-ext": [
+                    {
+                        "name": "flac",
+                        "dissemination": ["flac"],
+                        "preservation": "flac"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/audio/flac/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/audio/flac/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "name": "OPUS",
+                "file-ext": [
+                    {
+                        "name": "opus",
+                        "dissemination": ["opus"],
+                        "preservation": "opus"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/audio/opus/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/audio/opus/",
+                        "lang": "en"
+                    }
+                ]
+            }
+        ],
+        "non-preferred-format": [
+            {
+                "name": "WAVE",
+                "file-ext": [
+                    {
+                        "name": "wav",
+                        "dissemination": ["wav", "mka"],
+                        "preservation": "mka"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/bestandsformaten/audio/wave",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/audio/wav",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "name": "MP3",
+                "file-ext": [
+                    {
+                        "name": "mp3",
+                        "dissemination": ["mp3", "mka"],
+                        "preservation": "mka"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/audio/mp3/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/audio/mp3/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "name": "AAC",
+                "file-ext": [
+                    {
+                        "name": "aac",
+                        "dissemination": ["aac", "mka"],
+                        "preservation": "mka"
+                    },
+                    {
+                        "name": "m4a",
+                        "dissemination": ["m4a", "mka"],
+                        "preservation": "mka"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/audio/aac/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/audio/aac/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "name": "AIFF",
+                "file-ext": [
+                    {
+                        "name": "aif",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    },
+                    {
+                        "name": "aiff",
+                        "dissemination": ["aif", "mka"],
+                        "preservation": "mka"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/audio/aiff/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/audio/aiff/",
+                        "lang": "en"
+                    }
+                ]
+            }
+        ]
+    },
+
+    {
+        "type": [
+            {
+                "title": "Video",
+                "lang": "nl"
+            },
+            {
+                "title": "Video",
+                "lang": "en"
+            }
+        ],
+        "preferred-format": [
+            {
+                "name": "MXF",
+                "file-ext": [
+                    {
+                        "name": "mxf",
+                        "dissemination": ["mxf"],
+                        "preservation": "mxf"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/video/mxf/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/video/mxf/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "name": "Matroska",
+                "file-ext": [
+                    {
+                        "name": "mkv",
+                        "dissemination": ["mkv"],
+                        "preservation": "mkv"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/video/matroska/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/video/matroska/",
+                        "lang": "en"
+                    }
+                ]
+            }
+        ],
+        "non-preferred-format": [
+            {
+                "name": "MPEG-4",
+                "file-ext": [
+                    {
+                        "name": "mp4",
+                        "dissemination": ["mp4", "mkv"],
+                        "preservation": "mkv"
+                    },
+                    {
+                        "name": "m4a",
+                        "dissemination": ["m4a", "mkv"],
+                        "preservation": "mkv"
+                    },
+                    {
+                        "name": "m4v",
+                        "dissemination": ["m4v", "mkv"],
+                        "preservation": "mkv"
+                    }
+
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/video/mpeg-4/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/video/mpeg-4/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "name": "MPEG-2",
+                "file-ext": [
+                    {
+                        "name": "mpg",
+                        "dissemination": ["mpg", "mkv"],
+                        "preservation": "mkv"
+                    },
+                    {
+                        "name": "mpeg",
+                        "dissemination": ["mpeg", "mkv"],
+                        "preservation": "mkv"
+                    },
+                    {
+                        "name": "m2v",
+                        "dissemination": ["m2v", "mkv"],
+                        "preservation": "mkv"
+                    },
+                    {
+                        "name": "mpg2",
+                        "dissemination": ["mpg2", "mkv"],
+                        "preservation": "mkv"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/video/mpeg-2/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/video/mpeg-2/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "name": "AVI",
+                "file-ext": [
+                    {
+                        "name": "avi",
+                        "dissemination": ["avi", "mkv"],
+                        "preservation": "mkv"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/video/avi/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/video/avi/",
+                        "lang": "en"
+                    }
+                ]
+            },
+            {
+                "name": "QuickTime",
+                "file-ext": [
+                    {
+                        "name": "mov",
+                        "dissemination": ["mov", "mkv"],
+                        "preservation": "mkv"
+                    },
+                    {
+                        "name": "qt",
+                        "dissemination": ["qt", "mkv"],
+                        "preservation": "mkv"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/video/quicktime/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/video/quicktime/",
+                        "lang": "en"
+                    }
+                ]
+            }
+        ]
+    },
+
+    {
+        "type": [
+            {
+                "title": "Computer Aided Design (CAD)",
+                "lang": "nl"
+            },
+            {
+                "title": "Computer Aided Design (CAD)",
+                "lang": "en"
+            }
+        ],
+        "preferred-format": [
+            {
+                "name": "AutoCAD DXF versie R12 (ASCII)",
+                "file-ext": [
+                    {
+                        "name": "dxf",
+                        "dissemination": ["?"],
+                        "preservation": "?"
+                    }
+                ],
+                "info": [
+                    {
+                        "url": "https://dans.knaw.nl/nl/bestandsformaten/video/quicktime/",
+                        "lang": "nl"
+                    },
+                    {
+                        "url": "https://dans.knaw.nl/en/file-formats/video/quicktime/",
+                        "lang": "en"
+                    }
+                ]
+            }
+        ]
     }
 ]


### PR DESCRIPTION
### Description
Added all the formats from the [DANS File Formats page](https://dans.knaw.nl/en/file-formats/) and from the [new OH-SMART Requirements specification document](https://docs.google.com/document/d/1ZLMKsv0uzEQa7vDopprHF7ATZSIMd-SqkiEgTydHIJ0/edit#heading=h.wcgh6zgsf3dp).

### What has been done
- Added all the formats from sources mentioned above
- Adjusted schema:
     - Removed `pre-ingest`. The examples with `3GP`, `WMA`, `VOB`, `MOD` Audio/Video formats there just to show that we will request user to convert those files himself/herself before depositing. Those are just a separate examples, but it can be anything. So, I think the logic will be just if those formats not in the json file then request conversion and no additional keys needed, since we can predict all formats user can upload
     - `file-ext` is array now as I noticed that sometimes there is bunch of formats mentioned in parenthesises. Also file formats on the DANS page seems sub-divided by file format groups first.  For example, `Video -> MPEG-4` or `Video-MPEG-2`.
     - Moved `dissemination` and `preservation` to `file-ext` array, since we want to have that info per file extension
     - Removed `name` field and added `title` instead, because sometimes we have different literal per language there. For example, `Computer Aided Design (CAD) -> Autocad DXF, versie anders dan R12 (ASCII)` in Dutch and `Computer Aided Design (CAD) -> Autocad DXF, version different than R12 (ASCII)`
     - Added `url` field to `type` field - just to have another additional info